### PR TITLE
추억페이지 UI 개선

### DIFF
--- a/pochak/pochak.xcodeproj/project.pbxproj
+++ b/pochak/pochak.xcodeproj/project.pbxproj
@@ -2254,7 +2254,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = pochak/pochakDebug.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 2285AK4JY4;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2273,7 +2273,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.4;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.site.pochak.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -2294,7 +2294,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = pochak/pochak.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 2285AK4JY4;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2313,7 +2313,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.4;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.site.pochak.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/pochak/pochak/Network/Models/Memories/MemorySummary.swift
+++ b/pochak/pochak/Network/Models/Memories/MemorySummary.swift
@@ -12,12 +12,22 @@ struct MemorySummary: Codable {
     let memberProfileImage: String
     let handle: String
     let loginMemberProfileImage: String
-    let followDate: String?
-    let followedDate: String?
     let followDay: Int?
     let pochakCount, bondedCount, pochakedCount: Int
     let memories: [String: MemoryPost]
     let timeLine: [String: TimeLine]
+    let bondedDate: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case memberProfileImage
+        case handle
+        case loginMemberProfileImage
+        case followDay
+        case pochakCount, bondedCount, pochakedCount
+        case memories
+        case timeLine
+        case bondedDate = "f4fDate"
+    }
 }
 
 struct TimeLine: Codable {

--- a/pochak/pochak/Network/Models/Memories/MemorySummary.swift
+++ b/pochak/pochak/Network/Models/Memories/MemorySummary.swift
@@ -12,10 +12,11 @@ struct MemorySummary: Codable {
     let memberProfileImage: String
     let handle: String
     let loginMemberProfileImage: String
-    let followedDate: String
-    let followDay, pochakCount, bondedCount, pochakedCount: Int
+    let followDate: String?
+    let followedDate: String?
+    let followDay: Int?
+    let pochakCount, bondedCount, pochakedCount: Int
     let memories: [String: MemoryPost]
-    let followDate: String
     let timeLine: [String: TimeLine]
 }
 

--- a/pochak/pochak/Network/Models/Profile/ProfileRetrievalResponse.swift
+++ b/pochak/pochak/Network/Models/Profile/ProfileRetrievalResponse.swift
@@ -25,6 +25,21 @@ struct ProfileRetrievalResult : Codable {
     var isFollow: Bool?
     var pageInfo : ProfilePageInfo
     var postList : [ProfilePostList]
+    var isBonded: Bool?
+    
+    enum CodingKeys: String, CodingKey {
+        case handle
+        case profileImage
+        case name
+        case message
+        case totalPostNum
+        case followerCount
+        case followingCount
+        case isFollow
+        case pageInfo
+        case postList
+        case isBonded = "isF4F"
+    }
 }
 
 struct ProfilePageInfo : Codable {

--- a/pochak/pochak/UI/Memory/Main/MemoryViewController.swift
+++ b/pochak/pochak/UI/Memory/Main/MemoryViewController.swift
@@ -110,7 +110,7 @@ class MemoryViewController: UIViewController {
                 self.pochakMomentsView.isHidden = true
             }
             self.timelineView.configure(userID: memorySummary.handle,
-                                        followPeriod: Date.formatDateRange(fromDateString: memorySummary.followDate ?? ""),
+                                        followPeriod: Date.formatDateRange(fromDateString: memorySummary.bondedDate ?? ""),
                                         with: memorySummary.timeLine)
         }
     }

--- a/pochak/pochak/UI/Memory/Main/MemoryViewController.swift
+++ b/pochak/pochak/UI/Memory/Main/MemoryViewController.swift
@@ -101,10 +101,16 @@ class MemoryViewController: UIViewController {
         viewModel.onMemorySummaryUpdated = { [weak self] memorySummary in
             guard let self = self else { return }
             self.profileStatsView.configure(with: memorySummary)
-            // memories에서 postImage가 nil이 아닌 항목만 필터링
-            self.pochakMomentsView.configure(memoryList: viewModel.converGalleryPostList(memoryList: memorySummary.memories))
+            
+            let memoryCount = memorySummary.bondedCount + memorySummary.pochakCount + memorySummary.pochakedCount
+            
+            if memoryCount > 0 {
+                self.pochakMomentsView.configure(memoryList: viewModel.converGalleryPostList(memoryList: memorySummary.memories))
+            } else {
+                self.pochakMomentsView.isHidden = true
+            }
             self.timelineView.configure(userID: memorySummary.handle,
-                                        followPeriod: Date.formatDateRange(fromDateString: memorySummary.followDate),
+                                        followPeriod: Date.formatDateRange(fromDateString: memorySummary.followDate ?? ""),
                                         with: memorySummary.timeLine)
         }
     }

--- a/pochak/pochak/UI/Memory/Main/View/MemorySummaryView.swift
+++ b/pochak/pochak/UI/Memory/Main/View/MemorySummaryView.swift
@@ -95,9 +95,12 @@ class MemorySummaryView: UIView {
             myProfileView.load(with: url)
         }
         
-        let followPeriod = Date.formatDateRange(fromDateString: viewModel.followDate)
-        dateRangeLabel.text = followPeriod
-        postCountLabel.text = "서로 포착해준지 \(viewModel.followDay)일"
+        if let followDate = viewModel.followDate {
+            let followPeriod = Date.formatDateRange(fromDateString: followDate)
+            dateRangeLabel.text = followPeriod
+        }
+        
+        postCountLabel.text = "서로 포착해준지 \(viewModel.followDay ?? 0)일"
         setupStatsItems(pochakCount: viewModel.pochakCount,
                         bondedCount: viewModel.bondedCount,
                         pochakedCount: viewModel.pochakedCount)

--- a/pochak/pochak/UI/Memory/Main/View/MemorySummaryView.swift
+++ b/pochak/pochak/UI/Memory/Main/View/MemorySummaryView.swift
@@ -131,8 +131,9 @@ class MemorySummaryView: UIView {
         containerView.addSubview(dateRangeLabel)
         containerView.addSubview(postCountLabel)
         containerView.addSubview(statsStackView)
-        addSubview(friendProfileView)
-        addSubview(myProfileView)
+        addSubview(profileImageGroupView)
+        profileImageGroupView.addSubview(friendProfileView)
+        profileImageGroupView.addSubview(myProfileView)
         
         setupConstraints()
     }
@@ -188,22 +189,29 @@ class MemorySummaryView: UIView {
     }
     
     private func setupConstraints() {
+        profileImageGroupView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(148)
+            $0.height.equalTo(84)
+        }
+        
         friendProfileView.snp.makeConstraints {
             $0.top.equalToSuperview()
-            $0.leading.equalToSuperview().offset(102)
+            $0.leading.equalToSuperview()
             $0.width.height.equalTo(84)
         }
         
-        myProfileView.snp.makeConstraints { make in
-            make.centerY.equalTo(friendProfileView.snp.centerY)
-            make.left.equalTo(friendProfileView.snp.right).offset(-20)
-            make.width.height.equalTo(84)
+        myProfileView.snp.makeConstraints {
+            $0.centerY.equalTo(friendProfileView.snp.centerY)
+            $0.left.equalTo(friendProfileView.snp.right).offset(-20)
+            $0.width.height.equalTo(84)
         }
         
-        containerView.snp.makeConstraints { make in
-            make.top.equalTo(friendProfileView.snp.bottom).offset(-26)
-            make.height.equalTo(152)
-            make.width.equalToSuperview()
+        containerView.snp.makeConstraints {
+            $0.top.equalTo(profileImageGroupView.snp.bottom).offset(-26)
+            $0.height.equalTo(152)
+            $0.width.equalToSuperview()
         }
         
         dateRangeLabel.snp.makeConstraints {
@@ -211,16 +219,16 @@ class MemorySummaryView: UIView {
             $0.centerX.equalToSuperview()
         }
         
-        postCountLabel.snp.makeConstraints { make in
-            make.top.equalTo(dateRangeLabel.snp.bottom).offset(5)
-            make.centerX.equalToSuperview()
+        postCountLabel.snp.makeConstraints {
+            $0.top.equalTo(dateRangeLabel.snp.bottom).offset(5)
+            $0.centerX.equalToSuperview()
         }
         
-        statsStackView.snp.makeConstraints { make in
-            make.top.equalTo(postCountLabel.snp.bottom).offset(12)
-            make.centerX.equalToSuperview()
-            make.leading.trailing.equalToSuperview().inset(55)
-            make.height.equalTo(42)
+        statsStackView.snp.makeConstraints {
+            $0.top.equalTo(postCountLabel.snp.bottom).offset(12)
+            $0.centerX.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(55)
+            $0.height.equalTo(42)
         }
     }
     

--- a/pochak/pochak/UI/Memory/Main/View/MemorySummaryView.swift
+++ b/pochak/pochak/UI/Memory/Main/View/MemorySummaryView.swift
@@ -55,7 +55,7 @@ class MemorySummaryView: UIView {
     
     private let dateRangeLabel: UILabel = {
         let label = UILabel()
-        label.text = "2024년 5월 14일 ~ 2024년 10월 5일"
+        label.text = ""
         label.textColor = .black
         label.applyPochakFont(.body3_1)
         return label
@@ -63,7 +63,7 @@ class MemorySummaryView: UIView {
     
     private let postCountLabel: UILabel = {
         let label = UILabel()
-        label.text = "서로 포착해준지 167일"
+        label.text = ""
         label.textColor = .black
         label.applyPochakFont(.body3_1)
         return label
@@ -100,7 +100,8 @@ class MemorySummaryView: UIView {
             dateRangeLabel.text = followPeriod
         }
         
-        postCountLabel.text = "서로 포착해준지 \(viewModel.followDay ?? 0)일"
+        let followDay = viewModel.followDay ?? 0
+        postCountLabel.text = "서로 포착해준지 \(followDay+1)일"
         setupStatsItems(pochakCount: viewModel.pochakCount,
                         bondedCount: viewModel.bondedCount,
                         pochakedCount: viewModel.pochakedCount)

--- a/pochak/pochak/UI/Memory/Main/View/MemorySummaryView.swift
+++ b/pochak/pochak/UI/Memory/Main/View/MemorySummaryView.swift
@@ -95,7 +95,7 @@ class MemorySummaryView: UIView {
             myProfileView.load(with: url)
         }
         
-        if let followDate = viewModel.followDate {
+        if let followDate = viewModel.bondedDate {
             let followPeriod = Date.formatDateRange(fromDateString: followDate)
             dateRangeLabel.text = followPeriod
         }

--- a/pochak/pochak/UI/Memory/Main/View/MemorySummaryView.swift
+++ b/pochak/pochak/UI/Memory/Main/View/MemorySummaryView.swift
@@ -152,9 +152,11 @@ class MemorySummaryView: UIView {
     private func createStatsItemView(type: MemoryType, count: Int) -> UIView {
         let containerButton = UIButton()
         containerButton.tag = type.hashValue
-        containerButton.addAction(UIAction { _ in
-            self.didSelectMemoryCount(type: type)
-        }, for: .touchUpInside)
+        if count > 0 {
+            containerButton.addAction(UIAction { _ in
+                self.didSelectMemoryCount(type: type)
+            }, for: .touchUpInside)
+        }
 
         
         let titleLabel = UILabel()

--- a/pochak/pochak/UI/Memory/Main/View/TimelineView.swift
+++ b/pochak/pochak/UI/Memory/Main/View/TimelineView.swift
@@ -81,7 +81,7 @@ class TimelineView: UIView {
         
         timelineStackView.snp.makeConstraints {
             $0.top.equalTo(dateRangeLabel.snp.bottom).offset(16)
-            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.leading.trailing.equalToSuperview().inset(35)
             $0.bottom.equalToSuperview().offset(-16)
         }
         
@@ -92,7 +92,7 @@ class TimelineView: UIView {
         
         dateRangeLabel.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(8)
-            $0.leading.equalToSuperview().offset(16)
+            $0.leading.equalToSuperview().offset(32)
         }
     }
     

--- a/pochak/pochak/UI/Memory/Main/View/TimelineView.swift
+++ b/pochak/pochak/UI/Memory/Main/View/TimelineView.swift
@@ -81,7 +81,7 @@ class TimelineView: UIView {
         
         timelineStackView.snp.makeConstraints {
             $0.top.equalTo(dateRangeLabel.snp.bottom).offset(16)
-            $0.leading.trailing.equalToSuperview().inset(35)
+            $0.leading.trailing.equalToSuperview().inset(32)
             $0.bottom.equalToSuperview().offset(-16)
         }
         

--- a/pochak/pochak/UI/Memory/Main/View/TimelineView.swift
+++ b/pochak/pochak/UI/Memory/Main/View/TimelineView.swift
@@ -86,7 +86,7 @@ class TimelineView: UIView {
         }
         
         titleLabel.snp.makeConstraints {
-            $0.top.leading.equalToSuperview().offset(16)
+            $0.top.leading.equalToSuperview().offset(32)
             $0.height.equalTo(24)
         }
         

--- a/pochak/pochak/UI/Profile/OtherUserProfileViewController.swift
+++ b/pochak/pochak/UI/Profile/OtherUserProfileViewController.swift
@@ -385,12 +385,13 @@ final class OtherUserProfileViewController: UIViewController {
                 self.followToggleBtn.setTitle("팔로잉", for: .normal)
                 self.followToggleBtn.backgroundColor = UIColor(named: "gray03")
                 self.profileBackground.backgroundColor = UIColor(resource: .yellow00)
-                self.memoryButton.isHidden = false
             } else {
                 /// 팔로우하고 있지 않은 유저인 경우
                 self.followToggleBtn.setTitle("팔로우", for: .normal)
                 self.followToggleBtn.backgroundColor = UIColor(named: "yellow00")
             }
+            
+            self.memoryButton.isHidden = responseData.isBonded == false
         }
     }
     


### PR DESCRIPTION
## 💌 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 서로 팔로우한 상태일 때에만 추억페이지 버튼 보임
- 추억페이지에서 사진 갯수 0이면 버튼액션 동작 X
- 추억페이지에서 사진 갯수 1이상일 때에만 `POCHAK의 순간들` 노출
- 타임라인뷰 leading 패딩값 수정


## 💭 PR POINT

<!-- 덧붙이고 싶은 내용이 있다면! -->


## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 추억페이지에서 사진 갯수 1이상일 때에만 `POCHAK의 순간들` 노출  | <img src = "https://github.com/user-attachments/assets/d4e9ac55-3e8e-4cc7-a648-eb7e59fb3032" width ="250">|
| 추억페이지 날짜 계산 api response 수정 | <img src = "https://github.com/user-attachments/assets/1dbbafda-342b-40b8-9a78-cccadbc37971" width ="250">|



## 💐 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #124

