### PR TITLE
Fix: 회원가입 시 api 중복 요청 막기

### DIFF
--- a/pochak/pochak.xcodeproj/project.pbxproj
+++ b/pochak/pochak.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		0844D7F32BF21A80001154AC /* CancelViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0844D7F12BF21A80001154AC /* CancelViewCell.swift */; };
 		084AF4C72A5D831100C6454A /* HomeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084AF4C52A5D831100C6454A /* HomeCollectionViewCell.swift */; };
 		084AF4C82A5D831100C6454A /* HomeCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 084AF4C62A5D831100C6454A /* HomeCollectionViewCell.xib */; };
+		084CBB8A2E4B6A280059729B /* LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084CBB892E4B6A280059729B /* LoadingIndicator.swift */; };
 		08524D262D201C4F006C87E1 /* PochakNotificationService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 08224C0F2CCFBDF7002DA825 /* PochakNotificationService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		085AFD7A2E004B7200BA6077 /* CommentDeleteConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 085AFD792E004B7200BA6077 /* CommentDeleteConfirmView.swift */; };
 		0861E0E62D2578C3009E70A0 /* HandleDuplicateCheckButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0861E0E52D2578C3009E70A0 /* HandleDuplicateCheckButton.swift */; };
@@ -383,6 +384,7 @@
 		0844D7F12BF21A80001154AC /* CancelViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelViewCell.swift; sourceTree = "<group>"; };
 		084AF4C52A5D831100C6454A /* HomeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCollectionViewCell.swift; sourceTree = "<group>"; };
 		084AF4C62A5D831100C6454A /* HomeCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HomeCollectionViewCell.xib; sourceTree = "<group>"; };
+		084CBB892E4B6A280059729B /* LoadingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingIndicator.swift; sourceTree = "<group>"; };
 		085AFD792E004B7200BA6077 /* CommentDeleteConfirmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentDeleteConfirmView.swift; sourceTree = "<group>"; };
 		0861E0E52D2578C3009E70A0 /* HandleDuplicateCheckButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandleDuplicateCheckButton.swift; sourceTree = "<group>"; };
 		0861E0E72D259365009E70A0 /* UIResponder+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+.swift"; sourceTree = "<group>"; };
@@ -879,6 +881,7 @@
 			children = (
 				086BF2032CEC9D7800735BB4 /* FCMTokenManager.swift */,
 				0870EE9E2D86FE8000D6C43F /* AppStoreUpdateManager.swift */,
+				084CBB892E4B6A280059729B /* LoadingIndicator.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -1793,6 +1796,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				084CBB8A2E4B6A280059729B /* LoadingIndicator.swift in Sources */,
 				EA7EE1D82BF38921009486CC /* PochakAlarmTableViewCell.swift in Sources */,
 				376EA1302CAAAF6900FEFB63 /* ProfileService.swift in Sources */,
 				EA01079E2A59556800A3AE85 /* PostViewController.swift in Sources */,

--- a/pochak/pochak/Global/Helper/LoadingIndicator.swift
+++ b/pochak/pochak/Global/Helper/LoadingIndicator.swift
@@ -1,0 +1,37 @@
+//
+//  LoadingIndicator.swift
+//  pochak
+//
+//  Created by Suyeon Hwang on 8/12/25.
+//
+
+import UIKit
+
+class LoadingIndicator {
+    static func showLoading(color: UIColor) {
+        DispatchQueue.main.async {
+            // 최상단에 있는 window 객체 획득
+            guard let window = UIApplication.shared.windows.last else { return }
+
+            let loadingIndicatorView: UIActivityIndicatorView
+            if let existedView = window.subviews.first(where: { $0 is UIActivityIndicatorView } ) as? UIActivityIndicatorView {
+                loadingIndicatorView = existedView
+            } else {
+                loadingIndicatorView = UIActivityIndicatorView(style: .large)
+                /// 다른 UI가 눌리지 않도록 indicatorView의 크기를 full로 할당
+                loadingIndicatorView.frame = window.frame
+                loadingIndicatorView.color = color
+                window.addSubview(loadingIndicatorView)
+            }
+
+            loadingIndicatorView.startAnimating()
+        }
+    }
+
+    static func hideLoading() {
+        DispatchQueue.main.async {
+            guard let window = UIApplication.shared.windows.last else { return }
+            window.subviews.filter({ $0 is UIActivityIndicatorView }).forEach { $0.removeFromSuperview() }
+        }
+    }
+}

--- a/pochak/pochak/UI/Login/SignUpViewController.swift
+++ b/pochak/pochak/UI/Login/SignUpViewController.swift
@@ -294,6 +294,7 @@ final class SignUpViewController: UIViewController {
     }
     
     @objc private func doneButtonDidTap(_ sender: Any) {
+        LoadingIndicator.showLoading(color: UIColor(named: "yellow00")!)
         print("=== done buttone did tap ===")
         guard let nickname = nicknameTextField.text else { return }
         guard let id = idTextField.text else { return }
@@ -482,6 +483,7 @@ final class SignUpViewController: UIViewController {
     
     private func toHomeTabPage() {
         FCMTokenManager.shared.getPushNotificationPermission()
+        LoadingIndicator.hideLoading()
         
         let tabBarController = CustomTabBarController()
         let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate


### PR DESCRIPTION
## 💌 작업한 내용
- 회원가입 내용을 모두 입력한 후 '완료'버튼을 누르면 통신에 시간이 걸리는데, 그때 버튼 연타로 인해 동일 내용으로 회원가입 api 요청하는 문제를 막기 위해 '완료'버튼을 누르면 로딩창을 띄우도록 함.

## 💭 PR POINT
- 전역적으로 사용가능한 LoadingIndicator 를 구현함

## 📷 스크린샷
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/1e7428dd-039b-4e3a-a512-59b4b430ed1e" width ="250">|

## 💐 관련 이슈
- Resolved: #148 
