### PR TITLE
Fix: 댓글 소유자가 아닌 유저에게 삭제 버튼이 뜨는 문제

### DIFF
--- a/pochak/pochak/UI/Post/Comment/cell/CommentTableViewCell.swift
+++ b/pochak/pochak/UI/Post/Comment/cell/CommentTableViewCell.swift
@@ -234,6 +234,9 @@ final class CommentTableViewCell: UITableViewCell {
             print("이 유저는 댓글 삭제가 가능함")
             deleteButton.isHidden = false
         }
+        else {
+            deleteButton.isHidden = true
+        }
         
         // comment.uploadedTime 값: 2023-12-27T19:03:32.701
         // 시간 계산


### PR DESCRIPTION
## 💌 작업한 내용
- 현재 코드는 deleteButton의 isHidden이 true로 초기화되어있음을 전제로 작성되어있어서 문제가 발생하는 것이었음
- 댓글 작성이 불가능한 경우에 명시적으로 isHidden=false로 세팅

## 💭 PR POINT
- 

## 📷 스크린샷
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/408a659c-21d1-419d-beb7-5090065fe76b" width ="250">|

## 💐 관련 이슈
- Resolved: #151 
